### PR TITLE
Move GA date to July 2017

### DIFF
--- a/WebContent/index.html
+++ b/WebContent/index.html
@@ -117,7 +117,7 @@
 			</div>
 			<div class="divider-txt available">
 				|
-				<br> 23.3.2017
+				<br> 1.7.2017
 				<br> General Availability
 			</div>
 		</div>

--- a/WebContent/js/main.js
+++ b/WebContent/js/main.js
@@ -6,7 +6,7 @@ $(function() {
 	 */
 	var getDaysUntilRelease = function() {
 		var oneDay = 24*60*60*1000; // hours*minutes*seconds*milliseconds
-		var releaseDate = new Date(2017,03,23);
+		var releaseDate = new Date(2017,07,01);
 		var today = new Date();
 
 		var diffDays = Math.round(Math.abs((releaseDate.getTime() - today.getTime())/(oneDay)));


### PR DESCRIPTION
Yesterday Mark Reinhold proposed a four-month extension of the JDK 9 schedule, moving the General Availability (GA) milestone to July 2017. See: http://mail.openjdk.java.net/pipermail/jdk9-dev/2016-September/004887.html.
